### PR TITLE
Fix WSL clipboard paste

### DIFF
--- a/lua/options.lua
+++ b/lua/options.lua
@@ -59,8 +59,10 @@ if wsl_interop and wsl_interop:find("WSL") then
   vim.g.clipboard = {
     name = "WslClipboard",
     copy =  { ['+'] = 'clip.exe', ['*'] = 'clip.exe' },
-    paste = { ['+'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard))',
-              ['*'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard))' },
+    paste = {
+      ['+'] = 'powershell.exe -NoProfile -Command Get-Clipboard -Raw | tr -d \r',
+      ['*'] = 'powershell.exe -NoProfile -Command Get-Clipboard -Raw | tr -d \r',
+    },
     cache_enabled = 0,
   }
 end


### PR DESCRIPTION
## Summary
- handle multi-line text when pasting from Windows clipboard in WSL

## Testing
- `lua` not available

------
https://chatgpt.com/codex/tasks/task_e_68598cb86258832cb14b6d6a113c9380